### PR TITLE
Added "force-env" as a tag, making "force-value" deprecated

### DIFF
--- a/tests/env_test.go
+++ b/tests/env_test.go
@@ -50,7 +50,8 @@ type EnvWithDefault struct {
 }
 
 type EnvForceValue struct {
-    ThisIsForced string `env:"THIS_IS_FORCED" force-value:"true"`
+    ThisIsForced string `env:"FORCED_VALUE" force-value:"true"`
+    ThisIsAlsoForced string `env:"FORCED_VALUE" force-env:"true"`
 }
 
 type EnvironmentTestSuite struct {
@@ -247,12 +248,13 @@ func (suite *EnvironmentTestSuite) TestMultiLevelEnv() {
 func (suite *EnvironmentTestSuite) TestForceIndivdualError() {
     var config EnvForceValue
     err := env.Load(&config, env.Attributes{
-        EnvironmentFiles: []string{".env"},
+        EnvironmentFiles: []string{"faulty.env"},
     })
     suite.Error(err)
 
-    config.ThisIsForced = "lorem ipsum"
-    err = env.Load(&config, env.Attributes{})
+    err = env.Load(&config, env.Attributes{
+        EnvironmentFiles: []string{".env"},
+    })
     suite.NoError(err)
 }
 

--- a/tests/faulty.env
+++ b/tests/faulty.env
@@ -10,5 +10,3 @@ HOST=http://localhost
 EXTERNAL_SERVICE_HOST=http://example.com
 EXTERNAL_SERVICE_USERNAME=username
 EXTERNAL_SERVICE_PASSWORD=password
-
-FORCED_VALUE="lorem ipsum"


### PR DESCRIPTION
- Added "force-env" as tag, since it makes more sence.
- Added indicator of "force-value" being deprecated and will be removed.
- Fixed how values are set and used, in juxtaposition with the actual environment.