### PR TITLE
Added support for slices from environment.

### DIFF
--- a/tests/.env
+++ b/tests/.env
@@ -12,3 +12,5 @@ EXTERNAL_SERVICE_USERNAME=username
 EXTERNAL_SERVICE_PASSWORD=password
 
 FORCED_VALUE="lorem ipsum"
+
+STRING_SLICE=string1,string2,string3


### PR DESCRIPTION
The lib will now support environment-variables such as:
```
TEST=string1,string2
```
which will translate into slices.

This has been tested for string, integer and booleans. In theory this should work for all supported types, but it has not been thoroughly tested yet and will appreciate any bug-reports.