### PR TITLE
Swapped strings.Split to strings.SplitN

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -166,16 +166,12 @@ func parseEnvFile(path string) (map[string]string, error) {
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var val string
-		line := strings.Split(scanner.Text(), "=")
-		if len(line) == 0 {
+		line := strings.SplitN(scanner.Text(), "=", 2)
+		// Continue if we get a key without value.
+		if len(line) <= 1 || len(line[1]) == 0 {
 			continue
 		}
-		val = strings.Join(line[1:], "=")
-		if len(val) == 0 {
-			continue
-		}
-		values[line[0]] = val
+		values[line[0]] = line[1]
 	}
 	return values, scanner.Err()
 }


### PR DESCRIPTION
Swapped strings.Split to strings.SplitN and changed the following if-statement a bit.
We're now making the check for empty values on one row instead of two statements. First we check if the line we picked contains more than one item (key and value), and then we check that the second item (value) is not empty.